### PR TITLE
SubRip subtitles support

### DIFF
--- a/.github/workflows/github-gist-deploy.yml
+++ b/.github/workflows/github-gist-deploy.yml
@@ -1,6 +1,7 @@
 name: GitHub Gist Deploy
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/scripts/frame_lossless_cut.sh
+++ b/scripts/frame_lossless_cut.sh
@@ -48,7 +48,7 @@ function parse_arguments {
 
             if [[ "${to}"  =~ : ]]; then
                 TO+=("$(date --date "1970-01-01T${to}Z" +%s.%N)")
-            else
+            elif [[ -n "${to}" ]]; then
                 TO+=("${to}")
             fi
         fi

--- a/scripts/frame_lossless_cut.sh
+++ b/scripts/frame_lossless_cut.sh
@@ -7,6 +7,9 @@
 # Info:
 #   https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing and word splitting.
 #   https://www.shellcheck.net/wiki/SC2095 -- ffmpeg may swallow stdin, preventing this loop from working properly.
+#
+# Style:
+#   https://www.shellcheck.net/wiki/SC2248 -- Prefer double quoting even when variables don't contain special characters.
 
 set -e
 

--- a/scripts/frame_lossless_cut.sh
+++ b/scripts/frame_lossless_cut.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2095,SC1091,SC2086
+# shellcheck disable=SC2095,SC1091,SC2086,SC2248
 #
 # Warning:
 #   https://www.shellcheck.net/wiki/SC2095 -- Use ffmpeg -nostdin to prevent ffmpeg from swallowing stdin.

--- a/settings/sonarr.md
+++ b/settings/sonarr.md
@@ -12,7 +12,7 @@
 	  - [ ] `Series Folder Format` -> `{Series TitleYear} [tvdbid-{TvdbId}]`
 	  - [ ] `Season Folder Format` -> `Season {season:00}`
 	  - [ ] `Specials Folder Format` -> `Specials`
-	  - [ ] `Multi Episode Style` -> `Range`
+	  - [ ] `Multi Episode Style` -> `Prefixed Range`
 	- [ ] `Folders`
 	  - [ ] `Create Empty Series Folders` -> `Off`
 	  - [ ] `Delete Empty Folders` -> `Off`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds SubRip subtitle cutting/merging with reindexing and codec‑aware video recoding to `scripts/frame_lossless_cut.sh`, enables manual Gist deploy, and updates Sonarr multi‑episode style.
> 
> - **Scripts**:
>   - `scripts/frame_lossless_cut.sh`:
>     - Codec-aware recoding: detect input codec via `ffprobe`, choose `libx264`/`libx265`, set params, use stream `has_b_frames` and `r_frame_rate` for `-bf` and frame counting; adjust `keyint`.
>     - Subtitles: add SubRip (`.srt`) cutting with offset and reindexing; refactor ASS handling to copy/offset and append events; per-stream subtitle processing with accumulated `SUBTITLES_OFFSET`.
>     - Frame handling: improve normalization at start-of-file and rely on precomputed frame rate.
> - **CI**:
>   - `.github/workflows/github-gist-deploy.yml`: add `workflow_dispatch` trigger for manual runs.
> - **Settings**:
>   - `settings/sonarr.md`: change `Multi Episode Style` to `Prefixed Range`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a400d5cee3e4f5f3c9093332cc9cefb164ceff5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->